### PR TITLE
fix: pubsub libp2p services type-cast

### DIFF
--- a/src/heliaFetch.ts
+++ b/src/heliaFetch.ts
@@ -70,7 +70,7 @@ export class HeliaFetch {
           peerId: this.node.libp2p.peerId,
           services: {
             // mismatch types
-            pubsub: this.node.libp2p.services.pubsub
+            pubsub: this.node.libp2p.services.pubsub as Parameters<typeof pubsub>[0]['libp2p']['services']['pubsub']
           }
         }
       })


### PR DESCRIPTION
this fixes the pubsub type

I believe this is related to https://github.com/libp2p/js-libp2p/pull/1762 & https://github.com/libp2p/js-libp2p/discussions/2135 and their related issues.
